### PR TITLE
Handle ctx timeouts

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 	"regexp"
 	"strconv"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -145,7 +146,7 @@ ParseEachOutputLine:
 }
 
 func callConntrackTool() ([]string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3e9)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "conntrack", "--stats")


### PR DESCRIPTION
Catch context timeouts while running `conntrack` and report them as new metric `conntrack_stats_ctxtimeout`.

I've also lowered the context timeout from 50000 minutes (or am I wrong?) to 5 seconds.